### PR TITLE
Typo and Usability Corrections

### DIFF
--- a/css/kayaklaunch-global.css
+++ b/css/kayaklaunch-global.css
@@ -230,7 +230,7 @@ a:hover {
 }
 
 #launching-map {
-	height: 100%;
+	height: calc(100% - 31px);
 	padding: 0;
 }
 

--- a/route-lachen.html
+++ b/route-lachen.html
@@ -71,7 +71,7 @@
         <div class="hidden-xs hidden-sm hidden-md col-lg-1">
         </div>
         <div class="col-xs-12 col-sm-12 col-md-12 col-lg-10">
-          <p>An active day's paddling through the southern end of Lake Zürich, through the canals Pfäffikon, and in between the islands of Ufenau and Lützelau.</p>
+          <p>An active day's paddling through the southern end of Lake Zürich, through the canals at Pfäffikon, and in between the islands of Ufenau and Lützelau.</p>
         </div>
         <div class="hidden-xs hidden-sm hidden-md col-lg-1">
         </div>

--- a/routes.html
+++ b/routes.html
@@ -85,7 +85,7 @@
         </div>
         <div class="col-xs-12 col-sm-7 col-md-7  col-lg-6">
           <h2><a href="route-lachen.html">Lachen Round Trip</a></h2>
-          <p>An active day's paddling through the southern end of Lake Zürich, through the canals Pfäffikon, and in between the islands of Ufenau and Lützelau.</p>
+          <p>An active day's paddling through the southern end of Lake Zürich, through the canals at Pfäffikon, and in between the islands of Ufenau and Lützelau.</p>
         </div>
         <div class="col-xs-12 col-sm-5 col-md-5 col-lg-4">
           <div id="map-canvas-lachen" class="route-map-preview"></div>


### PR DESCRIPTION
* Corrected typo in Lachen route description
* Correct usability issue on 'launching spots' page
** Reduced height of the map canvas, to prevent the footer disappear off
the bottom of the page. This created and issue on touch screens where
the map controls could disappear behind the navbar