### PR TITLE
Removed footer from 'Launching Spots' page

### DIFF
--- a/css/kayaklaunch-global.css
+++ b/css/kayaklaunch-global.css
@@ -250,7 +250,7 @@ a:hover {
 }
 
 #launching-map {
-	height: calc(100% - 31px);
+  height: 100%;
 	padding: 0;
 }
 

--- a/launching.html
+++ b/launching.html
@@ -65,6 +65,7 @@
     <!-- End main page content -->
 
     <!-- Begin footer content -->
+    <!-- Footer removed on 'Launching Spots' page so as not to cover the map and Google's copyright notices
     <div id="footer">
       <div class="container">
         <div class="row">
@@ -81,6 +82,7 @@
         </div>
       </div>
     </div>
+    -->
     <!-- End footer content -->
 
     <!-- Bootstrap core JavaScript


### PR DESCRIPTION
Footer removed on 'Launching Spots' page so as not to cover the map and
Google's copyright notices