### PR TITLE
Correcting Layout Issue in 'Paddling Routes' page

### DIFF
--- a/routes.html
+++ b/routes.html
@@ -100,7 +100,7 @@
           <p>An active day's paddling through the southern end of Lake Zürich, through the canals at Pfäffikon, and in between the islands of Ufenau and Lützelau.</p>
         </div>
         <div class="routes-col-info col-xs-12 col-sm-2 col-md-2 col-lg-1">
-          <p></p>
+          <p>
             <span>
               <img class="icon" src="img/country-ch.png" /><br class="hidden-xs"/>
               Switzerland


### PR DESCRIPTION
* Removing extra closing 'p' tag to correct layout issue on 'Paddling
Routes' page