### PR TITLE
Google Maps API Cache Workaround

### DIFF
--- a/route-landsend.html
+++ b/route-landsend.html
@@ -214,7 +214,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCKaxuDRE8K0nnjW3-X-sGztahpmrZBC90&amp;libraries=places"></script>
     <script src="js/googlemaps-routes.js"></script>
     <script>
-      initializeMap('map-canvas', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/landsend.kml', true);
+      initializeMap('map-canvas', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/master/map/landsend.kml', true);
     </script>
 
 </body></html>

--- a/route-levanto.html
+++ b/route-levanto.html
@@ -152,6 +152,7 @@
               <th>Environment</th>
               <td>
                 <ul>
+                  <li>Very few landing sites are available along the coast; this is a committed journey</li>
                   <li>Numerous submerged and semi-submerged rocks are present along the cliffs, along with swell and tidal currents</li>
                     <ul>
                       <li>These rocks are excellent for rock hopping, however a helmet should be worn in these areas</li>
@@ -217,7 +218,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCKaxuDRE8K0nnjW3-X-sGztahpmrZBC90&amp;libraries=places"></script>
     <script src="js/googlemaps-routes.js"></script>
     <script>
-      initializeMap('map-canvas', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/levanto.kml', true);
+      initializeMap('map-canvas', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/master/map/levanto.kml', true);
     </script>
 
 </body></html>

--- a/routes.html
+++ b/routes.html
@@ -204,8 +204,8 @@
     <script>
       initializeMap('map-canvas-iseltwald', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/iseltwald.kml', false);
       initializeMap('map-canvas-lachen', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/lachen.kml', false);
-      initializeMap('map-canvas-levanto', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/levanto.kml', false);
-      initializeMap('map-canvas-landsend', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/gh-pages/map/landsend.kml', false);
+      initializeMap('map-canvas-levanto', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/master/map/levanto.kml', false);
+      initializeMap('map-canvas-landsend', 'https://raw.githubusercontent.com/binghamchris/kayaklaun.ch/master/map/landsend.kml', false);
     </script>
 
 </body></html>


### PR DESCRIPTION
* Changing links to Levanto and Land's End KML files from gh-pages to
master branch, as the Google Maps API appears to have incorrectly cached
empty KML files on the gh-pages branch and has not refreshed after
several days.
* Adding note on Levanto that it is a commited trip